### PR TITLE
Schemas can't be dropped if the migration table exists

### DIFF
--- a/src/Pacuna/Schemas/Schemas.php
+++ b/src/Pacuna/Schemas/Schemas.php
@@ -49,7 +49,7 @@ class Schemas
 
     public function drop($schemaName)
     {
-        $query = DB::statement('DROP SCHEMA '.$schemaName);
+        $query = DB::statement('DROP SCHEMA '.$schemaName . ' CASCADE');
     }
 
     public function migrate($schemaName, $args=[])


### PR DESCRIPTION
Trying to drop a schema when the migrations table still exists (even
after a migration:reset) causes the error

cannot drop schema fugit_eveniet because other objects depend on it
DETAIL:  table migrations depends on schema fugit_eveniet
HINT:  Use DROP ... CASCADE to drop the dependent objects too.

The simplest solution to this is to simply add 'CASCADE' to the drop
query.