### PR TITLE
Get current search path and set multiple search paths

### DIFF
--- a/src/Pacuna/Schemas/Schemas.php
+++ b/src/Pacuna/Schemas/Schemas.php
@@ -80,11 +80,18 @@ class Schemas
     /**
      * Set the search_path to the schema name
      *
-     * @param string $schemaName
+     * @param string|array $schemaName
      */
     public function switchTo($schemaName = 'public')
     {
-        $query = DB::statement('SET search_path TO ' . $schemaName);
+        if (!is_array($schemaName)) {
+            $schemaName = [$schemaName];
+        }
+
+        $query = 'SET search_path TO ' . implode(',', $schemaName);
+
+
+        $result = DB::statement($query);
     }
 
     /**

--- a/src/Pacuna/Schemas/Schemas.php
+++ b/src/Pacuna/Schemas/Schemas.php
@@ -151,4 +151,17 @@ class Schemas
 
         Artisan::call('migrate:rollback', $args);
     }
+
+    /**
+     * Return the current search path
+     *
+     * @return string
+     */
+    public function getSearchPath()
+    {
+        $query = DB::select('show search_path');
+        $searchPath = array_pop($query)->search_path;
+
+        return $searchPath;
+    }
 }


### PR DESCRIPTION
Add a method to get the current search path from PostgreSQL and also allow setting of multiple search paths by passing in an array to `switchTo`