### PR TITLE
Fix to make PGSchema::migrate work with Laravel 5.2.41 onwards

### DIFF
--- a/src/Pacuna/Schemas/Schemas.php
+++ b/src/Pacuna/Schemas/Schemas.php
@@ -5,6 +5,7 @@ namespace Pacuna\Schemas;
 use DB;
 use Artisan;
 use Schema;
+use Config;
 
 /**
  * Class Schemas

--- a/src/Pacuna/Schemas/Schemas.php
+++ b/src/Pacuna/Schemas/Schemas.php
@@ -84,6 +84,8 @@ class Schemas
      */
     public function switchTo($schemaName = 'public')
     {
+        $this->setSchemaInConnection($schemaName);
+
         if (!is_array($schemaName)) {
             $schemaName = [$schemaName];
         }
@@ -92,6 +94,16 @@ class Schemas
 
 
         $result = DB::statement($query);
+    }
+    
+    private function setSchemaInConnection($schemaName)
+    {
+        $driver = DB::connection()->getConfig('driver');
+        $config = Config::get("database.connections.$driver");
+        $config['schema'] = $schemaName;
+
+        DB::purge($driver);
+        Config::set("database.connections.$driver", $config);
     }
 
     /**


### PR DESCRIPTION
Changes the schema in the active DB connection so that the right schema is used when checking if a table exists (for instance in PGSchema::migrate($schemaName))

Closes #14 
