### PR TITLE
Quote the schema name when attempting to drop a schema

### DIFF
--- a/src/Pacuna/Schemas/Schemas.php
+++ b/src/Pacuna/Schemas/Schemas.php
@@ -74,7 +74,7 @@ class Schemas
      */
     public function create($schemaName)
     {
-        $query = DB::statement('CREATE SCHEMA ' . $schemaName);
+        $query = DB::statement('CREATE SCHEMA "' . $schemaName . '"');
     }
 
     /**
@@ -101,7 +101,7 @@ class Schemas
      */
     public function drop($schemaName)
     {
-        $query = DB::statement('DROP SCHEMA '.$schemaName . ' CASCADE');
+        $query = DB::statement('DROP SCHEMA "' . $schemaName . '" CASCADE');
     }
 
     /**


### PR DESCRIPTION
Currently you can't drop a schema if it starts with a number because PostgreSQL throws a syntax error

```
# drop schema 123;
ERROR:  42601: syntax error at or near "123"
LINE 1: drop schema 123;
                    ^
LOCATION:  scanner_yyerror, scan.l:1086
```

Simply wrapping the schema name in quotes allows it to be dropped correctly.